### PR TITLE
Improve TUI layout with progress indicator

### DIFF
--- a/internal/tui/mode_building.go
+++ b/internal/tui/mode_building.go
@@ -1,74 +1,72 @@
 package tui
 
 import (
-   "fmt"
-   "strings"
+	"fmt"
+	"strings"
 
-   tea "github.com/charmbracelet/bubbletea"
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 // renderBuilding renders the building mode view
 func (m Model) renderBuilding() string {
-   var b strings.Builder
-   b.WriteString(m.renderTitle())
-   b.WriteString("\n\n")
+	var b strings.Builder
 
-   if len(m.responses) > 0 {
-       b.WriteString("Building Mode - Code Implementation & Development\n")
-       b.WriteString(strings.Repeat("=", 50) + "\n")
+	if len(m.responses) > 0 {
+		b.WriteString("Building Mode - Code Implementation & Development\n")
+		b.WriteString(strings.Repeat("=", 50) + "\n")
 
-       start := m.scrollOffset
-       end := start + m.height - 15
-       if end > len(m.responses) {
-           end = len(m.responses)
-       }
+		start := m.scrollOffset
+		end := start + m.height - 15
+		if end > len(m.responses) {
+			end = len(m.responses)
+		}
 
-       for i := start; i < end; i++ {
-           response := m.responses[i]
-           if response.Mode == ViewModeBuilding {
-               b.WriteString(fmt.Sprintf("\n[%s] Q: %s\n", response.Time, response.Query))
-               if response.Answer != "" {
-                   b.WriteString("A: " + response.Answer + "\n")
-               }
-               b.WriteString(strings.Repeat("-", 50) + "\n")
-           }
-       }
+		for i := start; i < end; i++ {
+			response := m.responses[i]
+			if response.Mode == ViewModeBuilding {
+				b.WriteString(fmt.Sprintf("\n[%s] Q: %s\n", response.Time, response.Query))
+				if response.Answer != "" {
+					b.WriteString("A: " + response.Answer + "\n")
+				}
+				b.WriteString(strings.Repeat("-", 50) + "\n")
+			}
+		}
 
-       if len(m.responses) > end {
-           b.WriteString(fmt.Sprintf("\n... and %d more responses (use ↑/↓ to scroll)\n", len(m.responses)-end))
-       }
-   } else {
-       b.WriteString("🔨 Building Mode - Code Implementation & Development\n\n")
-       b.WriteString("This mode helps you:\n")
-       b.WriteString("• Implement new features and functionality\n")
-       b.WriteString("• Generate code examples and boilerplate\n")
-       b.WriteString("• Refactor and optimize existing code\n")
-       b.WriteString("• Create tests and documentation\n\n")
-       b.WriteString("Start by typing your development question below!\n")
-   }
+		if len(m.responses) > end {
+			b.WriteString(fmt.Sprintf("\n... and %d more responses (use ↑/↓ to scroll)\n", len(m.responses)-end))
+		}
+	} else {
+		b.WriteString("🔨 Building Mode - Code Implementation & Development\n\n")
+		b.WriteString("This mode helps you:\n")
+		b.WriteString("• Implement new features and functionality\n")
+		b.WriteString("• Generate code examples and boilerplate\n")
+		b.WriteString("• Refactor and optimize existing code\n")
+		b.WriteString("• Create tests and documentation\n\n")
+		b.WriteString("Start by typing your development question below!\n")
+	}
 
-   return b.String()
+	return b.String()
 }
 
 // updateBuilding handles events in building mode
 func (m Model) updateBuilding(msg tea.Msg) (Model, tea.Cmd) {
-   switch msg := msg.(type) {
-   case tea.KeyMsg:
-       switch msg.Type {
-       case tea.KeyEscape:
-           m.viewMode = ViewModeSelect
-       case tea.KeyUp:
-           if m.scrollOffset > 0 {
-               m.scrollOffset--
-           }
-       case tea.KeyDown:
-           if m.scrollOffset < len(m.responses)-1 {
-               m.scrollOffset++
-           }
-       }
-   case tea.WindowSizeMsg:
-       m.width = msg.Width
-       m.height = msg.Height
-   }
-   return m, nil
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.Type {
+		case tea.KeyEscape:
+			m.viewMode = ViewModeSelect
+		case tea.KeyUp:
+			if m.scrollOffset > 0 {
+				m.scrollOffset--
+			}
+		case tea.KeyDown:
+			if m.scrollOffset < len(m.responses)-1 {
+				m.scrollOffset++
+			}
+		}
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+	}
+	return m, nil
 }

--- a/internal/tui/mode_debugging.go
+++ b/internal/tui/mode_debugging.go
@@ -1,74 +1,72 @@
 package tui
 
 import (
-   "fmt"
-   "strings"
+	"fmt"
+	"strings"
 
-   tea "github.com/charmbracelet/bubbletea"
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 // renderDebugging renders the debugging mode view
 func (m Model) renderDebugging() string {
-   var b strings.Builder
-   b.WriteString(m.renderTitle())
-   b.WriteString("\n\n")
+	var b strings.Builder
 
-   if len(m.responses) > 0 {
-       b.WriteString("Debugging Mode - Error Analysis & Problem Solving\n")
-       b.WriteString(strings.Repeat("=", 50) + "\n")
+	if len(m.responses) > 0 {
+		b.WriteString("Debugging Mode - Error Analysis & Problem Solving\n")
+		b.WriteString(strings.Repeat("=", 50) + "\n")
 
-       start := m.scrollOffset
-       end := start + m.height - 15
-       if end > len(m.responses) {
-           end = len(m.responses)
-       }
+		start := m.scrollOffset
+		end := start + m.height - 15
+		if end > len(m.responses) {
+			end = len(m.responses)
+		}
 
-       for i := start; i < end; i++ {
-           response := m.responses[i]
-           if response.Mode == ViewModeDebugging {
-               b.WriteString(fmt.Sprintf("\n[%s] Q: %s\n", response.Time, response.Query))
-               if response.Answer != "" {
-                   b.WriteString("A: " + response.Answer + "\n")
-               }
-               b.WriteString(strings.Repeat("-", 50) + "\n")
-           }
-       }
+		for i := start; i < end; i++ {
+			response := m.responses[i]
+			if response.Mode == ViewModeDebugging {
+				b.WriteString(fmt.Sprintf("\n[%s] Q: %s\n", response.Time, response.Query))
+				if response.Answer != "" {
+					b.WriteString("A: " + response.Answer + "\n")
+				}
+				b.WriteString(strings.Repeat("-", 50) + "\n")
+			}
+		}
 
-       if len(m.responses) > end {
-           b.WriteString(fmt.Sprintf("\n... and %d more responses (use ↑/↓ to scroll)\n", len(m.responses)-end))
-       }
-   } else {
-       b.WriteString("🐛 Debugging Mode - Error Analysis & Problem Solving\n\n")
-       b.WriteString("This mode helps you:\n")
-       b.WriteString("• Analyze and fix runtime errors\n")
-       b.WriteString("• Debug logic issues and edge cases\n")
-       b.WriteString("• Trace execution flow and data\n")
-       b.WriteString("• Optimize performance bottlenecks\n\n")
-       b.WriteString("Describe your error or issue below!\n")
-   }
+		if len(m.responses) > end {
+			b.WriteString(fmt.Sprintf("\n... and %d more responses (use ↑/↓ to scroll)\n", len(m.responses)-end))
+		}
+	} else {
+		b.WriteString("🐛 Debugging Mode - Error Analysis & Problem Solving\n\n")
+		b.WriteString("This mode helps you:\n")
+		b.WriteString("• Analyze and fix runtime errors\n")
+		b.WriteString("• Debug logic issues and edge cases\n")
+		b.WriteString("• Trace execution flow and data\n")
+		b.WriteString("• Optimize performance bottlenecks\n\n")
+		b.WriteString("Describe your error or issue below!\n")
+	}
 
-   return b.String()
+	return b.String()
 }
 
 // updateDebugging handles events in debugging mode
 func (m Model) updateDebugging(msg tea.Msg) (Model, tea.Cmd) {
-   switch msg := msg.(type) {
-   case tea.KeyMsg:
-       switch msg.Type {
-       case tea.KeyEscape:
-           m.viewMode = ViewModeSelect
-       case tea.KeyUp:
-           if m.scrollOffset > 0 {
-               m.scrollOffset--
-           }
-       case tea.KeyDown:
-           if m.scrollOffset < len(m.responses)-1 {
-               m.scrollOffset++
-           }
-       }
-   case tea.WindowSizeMsg:
-       m.width = msg.Width
-       m.height = msg.Height
-   }
-   return m, nil
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.Type {
+		case tea.KeyEscape:
+			m.viewMode = ViewModeSelect
+		case tea.KeyUp:
+			if m.scrollOffset > 0 {
+				m.scrollOffset--
+			}
+		case tea.KeyDown:
+			if m.scrollOffset < len(m.responses)-1 {
+				m.scrollOffset++
+			}
+		}
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+	}
+	return m, nil
 }

--- a/internal/tui/mode_enhance.go
+++ b/internal/tui/mode_enhance.go
@@ -10,8 +10,6 @@ import (
 // renderEnhance renders the enhance mode view
 func (m Model) renderEnhance() string {
 	var b strings.Builder
-	b.WriteString(m.renderTitle())
-	b.WriteString("\n\n")
 
 	if len(m.responses) > 0 {
 		b.WriteString("Enhance Mode - Code Quality & Refactoring\n")

--- a/internal/tui/mode_planning.go
+++ b/internal/tui/mode_planning.go
@@ -1,74 +1,72 @@
 package tui
 
 import (
-   "fmt"
-   "strings"
+	"fmt"
+	"strings"
 
-   tea "github.com/charmbracelet/bubbletea"
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 // renderPlanning renders the planning mode view
 func (m Model) renderPlanning() string {
-   var b strings.Builder
-   b.WriteString(m.renderTitle())
-   b.WriteString("\n\n")
+	var b strings.Builder
 
-   if len(m.responses) > 0 {
-       b.WriteString("Planning Mode - Architecture & Strategy\n")
-       b.WriteString(strings.Repeat("=", 50) + "\n")
+	if len(m.responses) > 0 {
+		b.WriteString("Planning Mode - Architecture & Strategy\n")
+		b.WriteString(strings.Repeat("=", 50) + "\n")
 
-       start := m.scrollOffset
-       end := start + m.height - 15
-       if end > len(m.responses) {
-           end = len(m.responses)
-       }
+		start := m.scrollOffset
+		end := start + m.height - 15
+		if end > len(m.responses) {
+			end = len(m.responses)
+		}
 
-       for i := start; i < end; i++ {
-           response := m.responses[i]
-           if response.Mode == ViewModePlanning {
-               b.WriteString(fmt.Sprintf("\n[%s] Q: %s\n", response.Time, response.Query))
-               if response.Answer != "" {
-                   b.WriteString("A: " + response.Answer + "\n")
-               }
-               b.WriteString(strings.Repeat("-", 50) + "\n")
-           }
-       }
+		for i := start; i < end; i++ {
+			response := m.responses[i]
+			if response.Mode == ViewModePlanning {
+				b.WriteString(fmt.Sprintf("\n[%s] Q: %s\n", response.Time, response.Query))
+				if response.Answer != "" {
+					b.WriteString("A: " + response.Answer + "\n")
+				}
+				b.WriteString(strings.Repeat("-", 50) + "\n")
+			}
+		}
 
-       if len(m.responses) > end {
-           b.WriteString(fmt.Sprintf("\n... and %d more responses (use ↑/↓ to scroll)\n", len(m.responses)-end))
-       }
-   } else {
-       b.WriteString("📋 Planning Mode - Architecture & Strategy\n\n")
-       b.WriteString("This mode helps you:\n")
-       b.WriteString("• Design system architecture and data flows\n")
-       b.WriteString("• Plan feature implementation strategies\n")
-       b.WriteString("• Break down complex projects into tasks\n")
-       b.WriteString("• Create development roadmaps\n\n")
-       b.WriteString("What would you like to plan today?\n")
-   }
+		if len(m.responses) > end {
+			b.WriteString(fmt.Sprintf("\n... and %d more responses (use ↑/↓ to scroll)\n", len(m.responses)-end))
+		}
+	} else {
+		b.WriteString("📋 Planning Mode - Architecture & Strategy\n\n")
+		b.WriteString("This mode helps you:\n")
+		b.WriteString("• Design system architecture and data flows\n")
+		b.WriteString("• Plan feature implementation strategies\n")
+		b.WriteString("• Break down complex projects into tasks\n")
+		b.WriteString("• Create development roadmaps\n\n")
+		b.WriteString("What would you like to plan today?\n")
+	}
 
-   return b.String()
+	return b.String()
 }
 
 // updatePlanning handles events in planning mode
 func (m Model) updatePlanning(msg tea.Msg) (Model, tea.Cmd) {
-   switch msg := msg.(type) {
-   case tea.KeyMsg:
-       switch msg.Type {
-       case tea.KeyEscape:
-           m.viewMode = ViewModeSelect
-       case tea.KeyUp:
-           if m.scrollOffset > 0 {
-               m.scrollOffset--
-           }
-       case tea.KeyDown:
-           if m.scrollOffset < len(m.responses)-1 {
-               m.scrollOffset++
-           }
-       }
-   case tea.WindowSizeMsg:
-       m.width = msg.Width
-       m.height = msg.Height
-   }
-   return m, nil
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.Type {
+		case tea.KeyEscape:
+			m.viewMode = ViewModeSelect
+		case tea.KeyUp:
+			if m.scrollOffset > 0 {
+				m.scrollOffset--
+			}
+		case tea.KeyDown:
+			if m.scrollOffset < len(m.responses)-1 {
+				m.scrollOffset++
+			}
+		}
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+	}
+	return m, nil
 }

--- a/internal/tui/mode_select.go
+++ b/internal/tui/mode_select.go
@@ -10,8 +10,7 @@ import (
 // renderModeSelect renders the mode selection interface
 func (m Model) renderModeSelect() string {
 	var b strings.Builder
-	b.WriteString(m.renderTitle())
-	b.WriteString("\n\n")
+	b.WriteString("\n")
 	b.WriteString("Choose your RubrDuck mode:\n\n")
 
 	modes := []struct {

--- a/internal/tui/tui_validation_test.go
+++ b/internal/tui/tui_validation_test.go
@@ -34,8 +34,12 @@ func TestInteractiveFlow(t *testing.T) {
 		tmp, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
 		m = tmp.(Model)
 	}
-	tmp, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	tmp, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	m = tmp.(Model)
+	if cmd != nil {
+		tmp, _ = m.Update(cmd())
+		m = tmp.(Model)
+	}
 	assert.Len(t, m.responses, 2)
 	assert.Empty(t, m.input.Value())
 
@@ -44,8 +48,12 @@ func TestInteractiveFlow(t *testing.T) {
 		tmp, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
 		m = tmp.(Model)
 	}
-	tmp, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	tmp, cmd = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	m = tmp.(Model)
+	if cmd != nil {
+		tmp, _ = m.Update(cmd())
+		m = tmp.(Model)
+	}
 	assert.Len(t, m.responses, 4)
 
 	// Scroll up (when input not focused)
@@ -109,8 +117,12 @@ func TestAutoScrollOnOverflow(t *testing.T) {
 		tmp, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
 		m = tmp.(Model)
 		// submit
-		tmp, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+		tmp, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 		m = tmp.(Model)
+		if cmd != nil {
+			tmp, _ = m.Update(cmd())
+			m = tmp.(Model)
+		}
 	}
 
 	// After overflow, scrollOffset should be greater than zero
@@ -145,8 +157,12 @@ func TestComprehensiveUIBehavior(t *testing.T) {
 			tmp, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
 			m = tmp.(Model)
 		}
-		tmp, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+		tmp, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 		m = tmp.(Model)
+		if cmd != nil {
+			tmp, _ = m.Update(cmd())
+			m = tmp.(Model)
+		}
 		assert.Len(t, m.responses, (i+1)*2)
 		assert.Empty(t, m.input.Value())
 	}


### PR DESCRIPTION
## Summary
- add streaming progress state to the TUI model
- refactor view layout with separate title, content and status bars
- remove embedded title strings from mode renderers
- update tests for asynchronous message handling

## Testing
- `go test ./...` *(fails: TestShellTool_Timeout, TestShellTool_CommandOutput, TestShellTool_PathSanitization, TestServer_Start_Stop)*
- `go test ./internal/tui -run .`


------
https://chatgpt.com/codex/tasks/task_e_6863ed4b7c408330a294d669862a6361