### PR TITLE
Implement wire protocol definitions

### DIFF
--- a/pkg/protocol/protocol.go
+++ b/pkg/protocol/protocol.go
@@ -1,0 +1,88 @@
+package protocol
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ProtocolVersion is the current wire protocol version.
+const ProtocolVersion = "1.0"
+
+// SupportedVersions lists protocol versions this library understands.
+var SupportedVersions = []string{ProtocolVersion}
+
+// MessageType represents the high level category of a message.
+type MessageType string
+
+const (
+	// MessageTypeRequest is used for client requests.
+	MessageTypeRequest MessageType = "request"
+	// MessageTypeResponse is used for server responses.
+	MessageTypeResponse MessageType = "response"
+	// MessageTypeEvent is used for asynchronous events.
+	MessageTypeEvent MessageType = "event"
+	// MessageTypeError is used to signal an error occurred.
+	MessageTypeError MessageType = "error"
+	// MessageTypeVersion is used during the initial handshake.
+	MessageTypeVersion MessageType = "version"
+)
+
+// ErrorCode identifies a specific error condition.
+type ErrorCode string
+
+const (
+	// ErrInvalidRequest indicates the request was malformed.
+	ErrInvalidRequest ErrorCode = "invalid_request"
+	// ErrInternal is returned for unexpected server errors.
+	ErrInternal ErrorCode = "internal_error"
+	// ErrUnsupportedVersion is returned when the peer uses
+	// an unsupported protocol version.
+	ErrUnsupportedVersion ErrorCode = "unsupported_version"
+)
+
+// Error represents a wire protocol error.
+type Error struct {
+	Code    ErrorCode `json:"code"`
+	Message string    `json:"message"`
+}
+
+// Error implements the error interface.
+func (e *Error) Error() string {
+	if e == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+// Envelope wraps all protocol messages.
+type Envelope struct {
+	Type    MessageType     `json:"type"`
+	ID      string          `json:"id,omitempty"`
+	Version string          `json:"version,omitempty"`
+	Payload json.RawMessage `json:"payload,omitempty"`
+	Error   *Error          `json:"error,omitempty"`
+}
+
+// Event represents a streaming event payload.
+type Event struct {
+	Name string      `json:"name"`
+	Data interface{} `json:"data,omitempty"`
+}
+
+// StreamChunk represents a piece of streamed text data.
+type StreamChunk struct {
+	ID      string `json:"id"`
+	Content string `json:"content"`
+	Done    bool   `json:"done"`
+}
+
+// NegotiateVersion checks if the peerVersion is supported and
+// returns the version to use or an error if not supported.
+func NegotiateVersion(peerVersion string) (string, error) {
+	for _, v := range SupportedVersions {
+		if v == peerVersion {
+			return v, nil
+		}
+	}
+	return "", &Error{Code: ErrUnsupportedVersion, Message: fmt.Sprintf("version %s not supported", peerVersion)}
+}

--- a/pkg/protocol/protocol_test.go
+++ b/pkg/protocol/protocol_test.go
@@ -1,0 +1,71 @@
+package protocol
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestNegotiateVersion(t *testing.T) {
+	v, err := NegotiateVersion(ProtocolVersion)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if v != ProtocolVersion {
+		t.Fatalf("expected %s, got %s", ProtocolVersion, v)
+	}
+
+	if _, err := NegotiateVersion("2.0"); err == nil {
+		t.Fatalf("expected error for unsupported version")
+	}
+}
+
+func TestEnvelopeMarshal(t *testing.T) {
+	ev := Event{Name: "test", Data: "hello"}
+	payload, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+	env := Envelope{Type: MessageTypeEvent, ID: "1", Payload: payload, Version: ProtocolVersion}
+	data, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal envelope: %v", err)
+	}
+
+	var decoded Envelope
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+	if decoded.Type != MessageTypeEvent || decoded.ID != "1" || decoded.Version != ProtocolVersion {
+		t.Fatalf("unexpected envelope fields")
+	}
+
+	var got Event
+	if err := json.Unmarshal(decoded.Payload, &got); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if got.Name != ev.Name || got.Data.(string) != ev.Data {
+		t.Fatalf("payload mismatch")
+	}
+}
+
+func TestErrorString(t *testing.T) {
+	e := &Error{Code: ErrInvalidRequest, Message: "bad"}
+	if e.Error() != "invalid_request: bad" {
+		t.Fatalf("unexpected error string: %s", e.Error())
+	}
+}
+
+func TestStreamChunkMarshal(t *testing.T) {
+	chunk := StreamChunk{ID: "x", Content: "y", Done: true}
+	data, err := json.Marshal(chunk)
+	if err != nil {
+		t.Fatalf("marshal chunk: %v", err)
+	}
+	var got StreamChunk
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal chunk: %v", err)
+	}
+	if got != chunk {
+		t.Fatalf("unexpected chunk: %#v", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add protocol package with basic wire protocol constructs
- support version negotiation, event streaming, and error handling
- include thorough unit tests for the protocol

## Testing
- `make test`
- `make lint`

------
https://chatgpt.com/codex/tasks/task_e_68641408f2348330ac6d1e8adfa1b757