### PR TITLE
Implement project analysis tool

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -214,7 +214,11 @@ func (a *Agent) registerDefaultTools() {
 	gitTool := tools.NewGitTool(basePath)
 	a.RegisterTool("git_operations", gitTool)
 
-	log.Debug().Msg("Registered default tools: file_operations, shell_execute, git_operations")
+	// Register project analysis tool
+	projectTool := tools.NewProjectTool(basePath, a.config.Project)
+	a.RegisterTool("project_analyze", projectTool)
+
+	log.Debug().Msg("Registered default tools: file_operations, shell_execute, git_operations, project_analyze")
 }
 
 // getToolDefinitions returns tool definitions for the AI

--- a/internal/agent/tools/project.go
+++ b/internal/agent/tools/project.go
@@ -1,0 +1,48 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/hammie/rubrduck/internal/ai"
+	"github.com/hammie/rubrduck/internal/config"
+	"github.com/hammie/rubrduck/internal/project"
+	"github.com/rs/zerolog/log"
+)
+
+// ProjectTool analyzes the current project structure
+// and returns detected languages, frameworks, and files.
+type ProjectTool struct {
+	basePath string
+	cfg      config.ProjectConfig
+}
+
+// NewProjectTool creates a new project analysis tool
+func NewProjectTool(basePath string, cfg config.ProjectConfig) *ProjectTool {
+	return &ProjectTool{basePath: basePath, cfg: cfg}
+}
+
+func (p *ProjectTool) GetDefinition() ai.Tool {
+	return ai.Tool{
+		Type: "function",
+		Function: ai.ToolFunction{
+			Name:        "project_analyze",
+			Description: "Analyze the project structure and configuration",
+			Parameters:  map[string]interface{}{},
+		},
+	}
+}
+
+func (p *ProjectTool) Execute(ctx context.Context, args string) (string, error) {
+	info, err := project.AnalyzeProject(p.basePath, p.cfg)
+	if err != nil {
+		return "", fmt.Errorf("analysis failed: %w", err)
+	}
+	data, err := json.MarshalIndent(info, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal result: %w", err)
+	}
+	log.Debug().Msg("project analysis completed")
+	return string(data), nil
+}

--- a/internal/agent/tools/project_test.go
+++ b/internal/agent/tools/project_test.go
@@ -1,0 +1,39 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hammie/rubrduck/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProjectTool_Execute(t *testing.T) {
+	tempDir := t.TempDir()
+	// sample go file
+	goFile := filepath.Join(tempDir, "main.go")
+	require.NoError(t, os.WriteFile(goFile, []byte("package main"), 0644))
+
+	cfg := config.ProjectConfig{CodeExtensions: []string{".go"}}
+	tool := NewProjectTool(tempDir, cfg)
+
+	result, err := tool.Execute(context.Background(), "{}")
+	require.NoError(t, err)
+
+	var info map[string]interface{}
+	err = json.Unmarshal([]byte(result), &info)
+	require.NoError(t, err)
+
+	_, ok := info["languages"]
+	assert.True(t, ok)
+}
+
+func TestProjectTool_GetDefinition(t *testing.T) {
+	tool := NewProjectTool("/tmp", config.ProjectConfig{})
+	def := tool.GetDefinition()
+	assert.Equal(t, "project_analyze", def.Function.Name)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	API       APIConfig           `mapstructure:"api"`
 	History   HistoryConfig       `mapstructure:"history"`
 	Sandbox   SandboxPolicy       `mapstructure:"sandbox"`
+	Project   ProjectConfig       `mapstructure:"project"`
 	// TUI holds configuration for the terminal user interface
 	TUI TUIConfig `mapstructure:"tui"`
 }
@@ -72,6 +73,12 @@ type HistoryConfig struct {
 	MaxSize           int      `mapstructure:"max_size"`
 	SaveHistory       bool     `mapstructure:"save_history"`
 	SensitivePatterns []string `mapstructure:"sensitive_patterns"`
+}
+
+// ProjectConfig holds project-specific settings
+type ProjectConfig struct {
+	IgnorePaths    []string `mapstructure:"ignore_paths"`
+	CodeExtensions []string `mapstructure:"code_extensions"`
 }
 
 // Load loads the configuration from viper
@@ -155,6 +162,14 @@ func setDefaults() {
 	})
 	viper.SetDefault("sandbox.allowed_env_vars", []string{"PATH", "HOME", "USER", "PWD", "LANG", "LC_ALL"})
 	viper.SetDefault("sandbox.blocked_env_vars", []string{"SUDO_ASKPASS", "SSH_AUTH_SOCK", "GPG_AGENT_INFO"})
+
+	// Project defaults
+	viper.SetDefault("project.ignore_paths", []string{
+		"node_modules", ".git", "vendor", "dist", "build", "*.log", "*.tmp",
+	})
+	viper.SetDefault("project.code_extensions", []string{
+		".go", ".js", ".ts", ".py", ".java", ".cpp", ".c", ".h", ".rs", ".rb", ".php",
+	})
 
 	// TUI defaults
 	viper.SetDefault("tui.start_mode", "")

--- a/internal/project/analyzer.go
+++ b/internal/project/analyzer.go
@@ -1,0 +1,156 @@
+package project
+
+import (
+	"encoding/json"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/hammie/rubrduck/internal/config"
+)
+
+type FileInfo struct {
+	Path     string `json:"path"`
+	Size     int64  `json:"size"`
+	Language string `json:"language"`
+}
+
+type ProjectInfo struct {
+	Languages  map[string]int `json:"languages"`
+	Frameworks []string       `json:"frameworks"`
+	Configs    []string       `json:"configs"`
+	Files      []FileInfo     `json:"files"`
+}
+
+// AnalyzeProject scans the given directory and returns information about the codebase
+func AnalyzeProject(basePath string, cfg config.ProjectConfig) (*ProjectInfo, error) {
+	info := &ProjectInfo{
+		Languages: make(map[string]int),
+	}
+
+	err := filepath.WalkDir(basePath, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		rel, err := filepath.Rel(basePath, path)
+		if err != nil {
+			return nil
+		}
+		if shouldIgnore(rel, cfg.IgnorePaths) {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		ext := strings.ToLower(filepath.Ext(rel))
+		lang := languageFromExt(ext, cfg.CodeExtensions)
+		if lang != "" {
+			info.Languages[lang]++
+		}
+		basename := filepath.Base(rel)
+		switch basename {
+		case "package.json":
+			info.Frameworks = append(info.Frameworks, detectNodeFrameworks(path)...)
+			info.Configs = append(info.Configs, rel)
+		case "go.mod":
+			info.Frameworks = append(info.Frameworks, "go")
+			info.Configs = append(info.Configs, rel)
+		case "pyproject.toml", "requirements.txt":
+			info.Frameworks = append(info.Frameworks, "python")
+			info.Configs = append(info.Configs, rel)
+		case "composer.json":
+			info.Frameworks = append(info.Frameworks, "php")
+			info.Configs = append(info.Configs, rel)
+		}
+		stat, err := os.Stat(path)
+		if err == nil {
+			info.Files = append(info.Files, FileInfo{Path: rel, Size: stat.Size(), Language: lang})
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	info.Frameworks = uniqueStrings(info.Frameworks)
+	info.Configs = uniqueStrings(info.Configs)
+	return info, nil
+}
+
+func shouldIgnore(path string, patterns []string) bool {
+	for _, p := range patterns {
+		if strings.HasPrefix(path, p) {
+			return true
+		}
+		if ok, _ := filepath.Match(p, filepath.Base(path)); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func languageFromExt(ext string, allowed []string) string {
+	if ext == "" {
+		return ""
+	}
+	for _, a := range allowed {
+		if ext == a {
+			switch ext {
+			case ".go":
+				return "Go"
+			case ".js", ".ts":
+				return "JavaScript"
+			case ".py":
+				return "Python"
+			case ".java":
+				return "Java"
+			case ".cpp", ".c", ".h":
+				return "C/C++"
+			case ".rs":
+				return "Rust"
+			case ".rb":
+				return "Ruby"
+			case ".php":
+				return "PHP"
+			}
+		}
+	}
+	return ""
+}
+
+func detectNodeFrameworks(path string) []string {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var data struct {
+		Dependencies map[string]string `json:"dependencies"`
+		DevDeps      map[string]string `json:"devDependencies"`
+	}
+	if err := json.Unmarshal(content, &data); err != nil {
+		return nil
+	}
+	frameworks := []string{"node"}
+	for dep := range data.Dependencies {
+		switch dep {
+		case "react", "vue", "angular", "svelte", "express":
+			frameworks = append(frameworks, dep)
+		}
+	}
+	return frameworks
+}
+
+func uniqueStrings(in []string) []string {
+	m := make(map[string]struct{})
+	var out []string
+	for _, s := range in {
+		if _, ok := m[s]; !ok {
+			m[s] = struct{}{}
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/internal/project/analyzer_test.go
+++ b/internal/project/analyzer_test.go
@@ -1,0 +1,35 @@
+package project
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hammie/rubrduck/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnalyzeProject(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// create sample files
+	goFile := filepath.Join(tempDir, "main.go")
+	os.WriteFile(goFile, []byte("package main"), 0644)
+
+	pkgJSON := filepath.Join(tempDir, "package.json")
+	os.WriteFile(pkgJSON, []byte(`{"dependencies":{"express":"^4"}}`), 0644)
+
+	cfg := config.ProjectConfig{
+		IgnorePaths:    []string{},
+		CodeExtensions: []string{".go", ".js"},
+	}
+
+	info, err := AnalyzeProject(tempDir, cfg)
+	require.NoError(t, err)
+
+	assert.Contains(t, info.Languages, "Go")
+	assert.Contains(t, info.Frameworks, "express")
+	assert.Contains(t, info.Configs, "package.json")
+	require.Greater(t, len(info.Files), 0)
+}


### PR DESCRIPTION
## Summary
- add ProjectConfig and defaults to config
- implement project analyzer package for context awareness
- expose project_analyze tool via agent
- include unit tests for analyzer and tool

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6864142580848330baa82b744bb699c9