### PR TITLE
Add basic multi-modal image support

### DIFF
--- a/internal/ai/provider.go
+++ b/internal/ai/provider.go
@@ -28,11 +28,21 @@ type ChatRequest struct {
 }
 
 // Message represents a chat message
+// MessagePart represents either text or image content within a message.
+type MessagePart struct {
+	Type     string `json:"type"`                // "text" or "image_url"
+	Text     string `json:"text,omitempty"`      // text content
+	ImageURL string `json:"image_url,omitempty"` // URL or data URI for images
+}
+
+// Message represents a chat message. Content is kept for backwards
+// compatibility, while Parts enables multi-modal messages.
 type Message struct {
-	Role      string     `json:"role"`
-	Content   string     `json:"content"`
-	Name      string     `json:"name,omitempty"`
-	ToolCalls []ToolCall `json:"tool_calls,omitempty"`
+	Role      string        `json:"role"`
+	Content   string        `json:"content,omitempty"`
+	Parts     []MessagePart `json:"parts,omitempty"`
+	Name      string        `json:"name,omitempty"`
+	ToolCalls []ToolCall    `json:"tool_calls,omitempty"`
 }
 
 // Tool represents a function that can be called by the AI

--- a/internal/ai/providers/anthropic.go
+++ b/internal/ai/providers/anthropic.go
@@ -149,10 +149,29 @@ func (p *AnthropicProvider) convertRequest(req *ai.ChatRequest) map[string]inter
 	// Convert messages to Anthropic format
 	messages := make([]map[string]interface{}, len(req.Messages))
 	for i, msg := range req.Messages {
-		messages[i] = map[string]interface{}{
-			"role":    msg.Role,
-			"content": msg.Content,
+		m := map[string]interface{}{
+			"role": msg.Role,
 		}
+		if len(msg.Parts) > 0 {
+			parts := make([]map[string]interface{}, len(msg.Parts))
+			for j, part := range msg.Parts {
+				if part.Type == "image_url" {
+					parts[j] = map[string]interface{}{
+						"type":   "image",
+						"source": map[string]interface{}{"data": part.ImageURL, "media_type": "image/png"},
+					}
+				} else {
+					parts[j] = map[string]interface{}{
+						"type": "text",
+						"text": part.Text,
+					}
+				}
+			}
+			m["content"] = parts
+		} else {
+			m["content"] = msg.Content
+		}
+		messages[i] = m
 	}
 
 	anthropicReq := map[string]interface{}{


### PR DESCRIPTION
## Summary
- extend AI message format to allow image parts
- update OpenAI, Gemini, and Anthropic providers to handle image input

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686414512c148330aa28f7cee85e8e71